### PR TITLE
Fix a number of deprecation warnings

### DIFF
--- a/actionMenu/ActionMenu.hs
+++ b/actionMenu/ActionMenu.hs
@@ -16,13 +16,9 @@ import GI.Gtk.Objects.Widget
        (widgetShowAll, setWidgetHeightRequest, setWidgetWidthRequest,
         onWidgetDestroy)
 import GI.Gtk.Objects.TextView (textViewNew)
-import GI.Gtk.Objects.VBox (vBoxNew)
-import GI.Gtk.Objects.Box (boxPackStart, setBoxHomogeneous)
+import GI.Gtk.Objects.Box (boxNew, boxPackStart, setBoxHomogeneous)
 import GI.Gtk.Objects.Container (containerAdd)
-import GI.Gtk.Constants
-       (pattern STOCK_PASTE, pattern STOCK_COPY, pattern STOCK_CUT, pattern STOCK_QUIT,
-        pattern STOCK_SAVE_AS, pattern STOCK_SAVE, pattern STOCK_OPEN, pattern STOCK_NEW)
-import GI.Gtk.Enums (WindowType(..))
+import GI.Gtk.Enums (Orientation (..), WindowType(..))
 import qualified Data.Text as T (length)
 
 -- A function like this can be used to tag string literals for i18n.
@@ -76,35 +72,35 @@ main = do
   -- Create menu items
   newAct <- actionNew "NewAction" (Just (__"New"))
             (Just (__"Clear the spreadsheet area."))
-            (Just STOCK_NEW)
+            (Just "_New")
   onActionActivate newAct $ putStrLn "New activated."
   openAct <- actionNew "OpenAction" (Just (__"Open"))
             (Just (__"Open an existing spreadsheet."))
-            (Just STOCK_OPEN)
+            (Just "_Open")
   onActionActivate openAct $ putStrLn "Open activated."
   saveAct <- actionNew "SaveAction" (Just (__"Save"))
             (Just (__"Save the current spreadsheet."))
-            (Just STOCK_SAVE)
+            (Just "_Save")
   onActionActivate saveAct $ putStrLn "Save activated."
   saveAsAct <- actionNew "SaveAsAction" (Just (__"SaveAs"))
             (Just (__"Save spreadsheet under new name."))
-            (Just STOCK_SAVE_AS)
+            (Just "Save_As")
   onActionActivate saveAsAct $ putStrLn "SaveAs activated."
   exitAct <- actionNew "ExitAction" (Just (__"Exit"))
             (Just (__"Exit this application."))
-            (Just STOCK_QUIT)
+            (Just "_Quit")
   onActionActivate exitAct mainQuit
   cutAct <- actionNew "CutAction" (Just (__"Cut"))
             (Just (__"Cut out the current selection."))
-            (Just STOCK_CUT)
+            (Just "Cu_t")
   onActionActivate cutAct $ putStrLn "Cut activated."
   copyAct <- actionNew "CopyAction" (Just (__"Copy"))
             (Just (__"Copy the current selection."))
-            (Just STOCK_COPY)
+            (Just "_Copy")
   onActionActivate copyAct $ putStrLn "Copy activated."
   pasteAct <- actionNew "PasteAction" (Just (__"Paste"))
             (Just (__"Paste the current selection."))
-            (Just STOCK_PASTE)
+            (Just "_Paste")
   onActionActivate pasteAct $ putStrLn "Paste activated."
 
   standardGroup <- actionGroupNew ("standard"::Text)
@@ -124,7 +120,7 @@ main = do
   toolBar <- uIManagerGetWidget ui "/ui/toolbar"
 
   edit <- textViewNew
-  vBox <- vBoxNew False 0
+  vBox <- boxNew OrientationVertical 0
   setBoxHomogeneous vBox False
   boxPackStart vBox menuBar False False 0
   boxPackStart vBox toolBar False False 0

--- a/carsim/CarSim.hs
+++ b/carsim/CarSim.hs
@@ -13,20 +13,20 @@ import Prelude
 import Data.Maybe
 import GI.Gtk
        (widgetShowAll, onWidgetDestroy, setWindowDefaultHeight,
-        setWindowDefaultWidth, setWindowTitle, boxPackStart, hBoxNew,
-        vBoxNew, frameSetShadowType, aspectFrameNew,
+        setWindowDefaultWidth, setWindowTitle, boxPackStart, boxNew,
+        frameSetShadowType, aspectFrameNew,
         widgetGetAllocatedHeight, widgetGetAllocatedWidth, onWidgetDraw,
         onWidgetLeaveNotifyEvent, onWidgetMotionNotifyEvent,
         widgetAddEvents, alignmentSetPadding, alignmentNew, rangeSetValue,
         scaleSetDigits, scaleSetValuePos, rangeGetValue,
-        afterScaleButtonValueChanged, vScaleNewWithRange, containerAdd,
-        hButtonBoxNew, mainQuit, onButtonActivate, pattern STOCK_QUIT, pattern STOCK_ABOUT,
+        afterScaleButtonValueChanged, scaleNewWithRange, containerAdd,
+        buttonBoxNew, mainQuit, onButtonActivate,
         toggleButtonGetActive, onToggleButtonToggled, buttonSetUseStock,
-        pattern STOCK_MEDIA_PAUSE, toggleButtonNewWithLabel, onButtonClicked,
-        pattern STOCK_CLEAR, buttonNewFromStock, widgetQueueDraw, drawingAreaNew,
+        toggleButtonNewWithLabel, onButtonClicked,
+        buttonNewWithLabel, widgetQueueDraw, drawingAreaNew,
         windowNew, widgetDestroy, dialogRun, setAboutDialogComments,
         setAboutDialogAuthors, setAboutDialogVersion,
-        setAboutDialogProgramName, aboutDialogNew)
+        setAboutDialogProgramName, aboutDialogNew, labelNew)
 import GI.Cairo
 import Control.Monad
 import Data.IORef
@@ -46,7 +46,7 @@ import GI.Gdk
 import GI.Gdk.Flags (EventMask(..))
 import Control.Monad.Trans.Reader (ReaderT(..))
 import GI.Gtk.Enums
-       (WindowType(..), ShadowType(..), PositionType(..))
+       (Orientation(..), WindowType(..), ShadowType(..), PositionType(..))
 import Data.Monoid ((<>))
 import Data.GI.Base.BasicConversions (gflagsToWord)
 import Graphics.Rendering.Cairo.Types (Cairo(..))
@@ -197,29 +197,28 @@ main = do
 
     buttons <- do
 
-        qr <- buttonNewFromStock STOCK_CLEAR
+        qr <- buttonNewWithLabel "Clear"
         onButtonClicked qr $ do
             (liftM length) getCars >>= setCars . newCarList
             getCurrentTime >>= setTimeStamp
             widgetQueueDraw drawingArea
 
-        qp <- toggleButtonNewWithLabel STOCK_MEDIA_PAUSE
-        buttonSetUseStock qp True
+        qp <- toggleButtonNewWithLabel "Pause"
         onToggleButtonToggled qp $ do
             p <- toggleButtonGetActive qp
             if p
                 then pause
                 else resume
 
-        qa <- buttonNewFromStock STOCK_ABOUT
+        qa <- buttonNewWithLabel "About"
         onButtonClicked qa about
 
-        qq <- buttonNewFromStock STOCK_QUIT
-        onButtonActivate qq (do
+        qq <- buttonNewWithLabel "Quit"
+        onButtonClicked qq (do
                        widgetDestroy mainWindow
                        mainQuit)
 
-        bb <- hButtonBoxNew
+        bb <- buttonBoxNew OrientationHorizontal
         containerAdd bb qr
         containerAdd bb qp
         containerAdd bb qa
@@ -228,7 +227,7 @@ main = do
 
     howMany <- do
 
-        sc <- vScaleNewWithRange 1 40 1
+        sc <- scaleNewWithRange OrientationVertical 1 40 1
         afterScaleButtonValueChanged sc $ \_ -> do
             v <- floor <$> rangeGetValue sc
             c <- getCars
@@ -280,8 +279,8 @@ main = do
     -- properly arranged.
 
     layout <- do
-        vb <- vBoxNew False 0
-        hb <- hBoxNew False 0
+        vb <- boxNew OrientationVertical 0
+        hb <- boxNew OrientationHorizontal 0
         boxPackStart vb track True True 0
         boxPackStart vb buttons False False 0
         boxPackStart hb howMany False False 0

--- a/concurrent/Progress.hs
+++ b/concurrent/Progress.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 -- Example of concurrent Haskell and Gtk.
 --
@@ -22,7 +23,7 @@ main :: IO ()
 main = do
   GI.init Nothing
   dia <- dialogNew
-  dialogAddButton dia STOCK_CLOSE (fromIntegral $ fromEnum ResponseTypeClose)
+  dialogAddButton dia "_Close" (fromIntegral $ fromEnum ResponseTypeClose)
   contain <- dialogGetContentArea dia
   pb <- progressBarNew
   boxPackStart contain pb False False 0

--- a/concurrent/ProgressThreadedRTS.hs
+++ b/concurrent/ProgressThreadedRTS.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 -- Example of concurrent Haskell and Gtk.
 --
@@ -15,7 +16,7 @@ import Control.Concurrent
 import qualified GI.Gtk as GI (init)
 import GI.Gtk
        (progressBarPulse, ProgressBar, dialogRun, widgetShowAll,
-        boxPackStart, progressBarNew, dialogGetContentArea, pattern STOCK_CLOSE,
+        boxPackStart, progressBarNew, dialogGetContentArea,
         dialogAddButton, dialogNew)
 import GI.Gtk.Enums (ResponseType(..))
 import GI.GLib (pattern PRIORITY_DEFAULT, idleAdd)
@@ -26,7 +27,7 @@ main = do
   GI.init Nothing
 
   dia <- dialogNew
-  dialogAddButton dia STOCK_CLOSE (fromIntegral $ fromEnum ResponseTypeClose)
+  dialogAddButton dia "_Close" (fromIntegral $ fromEnum ResponseTypeClose)
   contain <- dialogGetContentArea dia
   pb <- progressBarNew
   boxPackStart contain pb False False 0

--- a/fastdraw/FastDraw.hs
+++ b/fastdraw/FastDraw.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS -O #-}
 
 -- Example of an drawing graphics onto a canvas.
@@ -15,7 +16,7 @@ import qualified GI.Gtk as GI (init)
 import GI.Gtk
        (dialogRun, widgetShow, boxPackStart, onWidgetDraw,
         widgetQueueDraw, setWidgetHeightRequest, setWidgetWidthRequest,
-        drawingAreaNew, dialogGetContentArea, pattern STOCK_OK, dialogAddButton,
+        drawingAreaNew, dialogGetContentArea, dialogAddButton,
         dialogNew)
 import GI.Gtk.Enums (ResponseType(..))
 import GI.GLib (pattern PRIORITY_LOW, idleAdd)
@@ -29,7 +30,7 @@ import Graphics.Rendering.Cairo.Internal (Render(..))
 main = do
   GI.init Nothing
   dia <- dialogNew
-  dialogAddButton dia STOCK_OK (fromIntegral $ fromEnum ResponseTypeOk)
+  dialogAddButton dia "_OK" (fromIntegral $ fromEnum ResponseTypeOk)
   contain <- dialogGetContentArea dia
   canvas <- drawingAreaNew
   let w = 256

--- a/notebook/Notebook.hs
+++ b/notebook/Notebook.hs
@@ -18,14 +18,14 @@ import GI.Gtk
         IsWidget, IsBox, imageNewFromPixbuf, iconThemeLoadIcon,
         iconThemeGetDefault, Image, spinnerStop, widgetShow, spinnerStart,
         labelSetText, setWindowTitle, boxPackStart, toolButtonNew,
-        spinnerNew, hBoxNew, mainQuit, onWidgetDestroy, containerAdd,
+        spinnerNew, boxNew, mainQuit, onWidgetDestroy, containerAdd,
         notebookRemovePage, notebookPageNum, onToolButtonClicked,
         notebookAppendPageMenu, labelNew, widgetShowAll, textViewNew,
         onWidgetKeyPressEvent, windowSetPosition, windowSetDefaultSize,
-        notebookNew, windowNew, ToolButton, Label, Spinner, HBox)
+        notebookNew, windowNew, ToolButton, Label, Spinner, Box)
 import qualified Data.Text as T (unpack)
 import qualified GI.Gtk as Gtk (main, init)
-import GI.Gtk.Enums (WindowType(..), WindowPosition(..))
+import GI.Gtk.Enums (Orientation(..), WindowType(..), WindowPosition(..))
 import Data.GI.Base.Attributes (AttrOp(..), set)
 import GI.Gdk (keyvalName, getEventKeyKeyval, getEventKeyState)
 import GI.Gdk.Flags (ModifierType(..))
@@ -35,7 +35,7 @@ import Control.Exception (catch)
 import Data.GI.Base.BasicTypes (UnexpectedNullPointerReturn(..))
 
 data NotebookTab =
-    NotebookTab {ntBox          :: HBox
+    NotebookTab {ntBox          :: Box
                 ,ntSpinner      :: Spinner
                 ,ntLabel        :: Label
                 ,ntCloseButton  :: ToolButton
@@ -101,7 +101,7 @@ notebookTabNew :: Maybe Text -> Maybe Int -> IO NotebookTab
 notebookTabNew name size = do
   -- Init.
   let iconSize = fromMaybe 12 size
-  box <- hBoxNew False 0
+  box <- boxNew OrientationHorizontal 0
   spinner <- spinnerNew
   label <- labelNew name
   image <- imageNewFromIcon "window-close" iconSize

--- a/overlay/Overlay.hs
+++ b/overlay/Overlay.hs
@@ -3,12 +3,12 @@ module Main (main) where
 
 import GI.Gtk
        (overlayAddOverlay, widgetShowAll, setButtonBoxLayoutStyle,
-        containerAdd, hButtonBoxNew, setWidgetMarginBottom,
+        containerAdd, buttonBoxNew, setWidgetMarginBottom,
         setWidgetMarginLeft, boxPackStart, buttonNewWithLabel, labelNew,
-        vBoxNew, setContainerChild, overlayNew, setContainerBorderWidth,
+        boxNew, setContainerChild, overlayNew, setContainerBorderWidth,
         mainQuit, onWidgetDestroy, windowNew)
 import qualified GI.Gtk as Gtk (main, init)
-import GI.Gtk.Enums (ButtonBoxStyle(..), WindowType(..))
+import GI.Gtk.Enums (ButtonBoxStyle(..), Orientation(..), WindowType(..))
 
 main :: IO ()
 main = do
@@ -27,7 +27,7 @@ main = do
 
   setContainerChild window overlay
 
-  vbox <- vBoxNew True 3
+  vbox <- boxNew OrientationVertical 3
   label1 <- labelNew (Just "This is an overlayed label")
   button <- buttonNewWithLabel "another one"
   label3 <- labelNew (Just "and a final one")
@@ -40,7 +40,7 @@ main = do
 
   overlayAddOverlay overlay vbox
 
-  hbuttonbox <- hButtonBoxNew
+  hbuttonbox <- buttonBoxNew OrientationHorizontal
 
   containerAdd overlay hbuttonbox
 

--- a/statusicon/StatusIcon.hs
+++ b/statusicon/StatusIcon.hs
@@ -7,12 +7,12 @@ import GI.Gtk
         menuShellAppend, menuItemNewWithLabel, mainQuit, menuNew,
         onStatusIconActivate, menuPopup, widgetShowAll,
         onStatusIconPopupMenu, statusIconSetTooltipText,
-        statusIconSetVisible, pattern STOCK_QUIT, statusIconNewFromStock)
+        statusIconSetVisible, statusIconNewFromStock)
 import qualified GI.Gtk as Gtk (main, init)
 
 main = do
   Gtk.init Nothing
-  icon <- statusIconNewFromStock STOCK_QUIT
+  icon <- statusIconNewFromStock "_Quit"
   statusIconSetVisible icon True
   statusIconSetTooltipText icon "This is a test"
   menu <- mkmenu icon

--- a/unicode/Arabic.hs
+++ b/unicode/Arabic.hs
@@ -4,8 +4,8 @@
 -- Example of an international dialog box.
 import GI.Gtk
        (Box(..), dialogRun, widgetShowAll, boxPackStart, labelSetMarkup,
-        labelNew, dialogGetContentArea, pattern STOCK_NO, pattern STOCK_YES,
-        dialogAddButton, dialogNew, pattern STOCK_OK, widgetShow)
+        labelNew, dialogGetContentArea,
+        dialogAddButton, dialogNew, widgetShow)
 
 import Control.Applicative
 import Prelude
@@ -20,8 +20,8 @@ main :: IO ()
 main = do
   Gtk.init Nothing
   dia <- dialogNew
-  dialogAddButton dia STOCK_YES (fromIntegral $ fromEnum ResponseTypeYes)
-  dialogAddButton dia STOCK_NO (fromIntegral $ fromEnum ResponseTypeNo)
+  dialogAddButton dia "Yes" (fromIntegral $ fromEnum ResponseTypeYes)
+  dialogAddButton dia "No" (fromIntegral $ fromEnum ResponseTypeNo)
   contain <- dialogGetContentArea dia >>= unsafeCastTo Box
   theText <- labelNew (Nothing :: Maybe Text)
   labelSetMarkup theText (T.pack arabic)
@@ -45,7 +45,7 @@ arabic = markSpan ["size=\"36000\""]  $
 yell :: IO ()
 yell = do
   dia <- dialogNew
-  dialogAddButton dia STOCK_OK (fromIntegral $ fromEnum ResponseTypeOk)
+  dialogAddButton dia "OK" (fromIntegral $ fromEnum ResponseTypeOk)
   contain <- dialogGetContentArea dia >>= unsafeCastTo Box
   msg <- labelNew (Just "This is not an option.")
   boxPackStart contain msg False False 0


### PR DESCRIPTION
The GTK developers seem to have an immense hatred of developers.
They deprecate functions at the drop of a hat and often provide
zero documentation on what to do to replace the now deprecated
functionality.

Started work on removing deprecation warnings. These are the easy ones. I don't think I've broken anything but would appreciate feedback if I've got anything wrong.