### PR TITLE
Fix type error

### DIFF
--- a/carsim/CarSim.hs
+++ b/carsim/CarSim.hs
@@ -19,7 +19,7 @@ import GI.Gtk
         onWidgetLeaveNotifyEvent, onWidgetMotionNotifyEvent,
         widgetAddEvents, alignmentSetPadding, alignmentNew, rangeSetValue,
         scaleSetDigits, scaleSetValuePos, rangeGetValue,
-        afterScaleButtonValueChanged, scaleNewWithRange, containerAdd,
+        onRangeValueChanged, setRangeInverted, scaleNewWithRange, containerAdd,
         buttonBoxNew, mainQuit, onButtonActivate,
         toggleButtonGetActive, onToggleButtonToggled, buttonSetUseStock,
         toggleButtonNewWithLabel, onButtonClicked,
@@ -227,7 +227,8 @@ main = do
     howMany <- do
 
         sc <- scaleNewWithRange OrientationVertical 1 40 1
-        afterScaleButtonValueChanged sc $ \_ -> do
+        setRangeInverted sc True
+        onRangeValueChanged sc $ do
             v <- floor <$> rangeGetValue sc
             c <- getCars
             setCars $ newCarListFromList v c


### PR DESCRIPTION
The current code will cause the following type error:
```
src/Main.hs:230:9: error:
    • Required ancestor ‘GI.Gtk.Objects.ScaleButton.ScaleButton’ not found for type ‘GI.Gtk.Objects.Scale.Scale’.
    • In the expression: afterScaleButtonValueChanged sc
      In a stmt of a 'do' block:
        afterScaleButtonValueChanged sc
        $ \ _
            -> do { v <- floor <$> rangeGetValue sc;
                    c <- getCars;
                    .... }
      In a stmt of a 'do' block:
        howMany <- do { sc <- scaleNewWithRange OrientationVertical 1 40 1;
                        afterScaleButtonValueChanged sc $ \ _ -> do { ... };
                        scaleSetValuePos sc PositionTypeTop;
                        scaleSetDigits sc 0;
                        .... }
```
`afterScaleButtonValueChanged` expects a `ScaleButton`, but `sc` is a `Scale`.

This PR contains a fix.